### PR TITLE
Add SQLx offline queries; all crates published

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,12 +220,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
-
-[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,9 +711,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "calloop"
@@ -826,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -836,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1670,9 +1664,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1877,19 +1871,6 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -2218,11 +2199,12 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.20"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "bytes",
+ "futures-core",
  "http",
  "http-body",
  "hyper",
@@ -2337,12 +2319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2403,8 +2379,6 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -2497,12 +2471,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2510,9 +2478,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libloading"
@@ -2618,9 +2586,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
@@ -3186,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "open-timeline-crud"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "bool-tag-expr",
@@ -3306,9 +3274,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "5.1.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
 ]
@@ -3586,16 +3554,6 @@ name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.114",
-]
 
 [[package]]
 name = "proc-macro-crate"
@@ -3915,9 +3873,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.23"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "same-file"
@@ -4526,12 +4484,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
  "windows-sys 0.61.2",
@@ -4613,9 +4571,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
 dependencies = [
  "deranged",
  "itoa",
@@ -4636,9 +4594,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4906,9 +4864,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-normalization"
@@ -4933,9 +4891,9 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.2"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
@@ -5024,15 +4982,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5095,40 +5044,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.10.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -5288,9 +5203,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.1.0"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f00bb839c1cf1e3036066614cbdcd035ecf215206691ea646aa3c60a24f68f2"
+checksum = "00f1243ef785213e3a32fa0396093424a3a6ea566f9948497e5a2309261a4c97"
 dependencies = [
  "core-foundation 0.10.1",
  "jni",
@@ -6075,88 +5990,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.114",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.10.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -6349,18 +6182,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6429,9 +6262,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.20"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
+checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "3"
 
 [workspace.dependencies]
 open-timeline-core = { version = "0.1.0", path = "crates/core" }
-open-timeline-crud = { version = "0.1.1", path = "crates/crud" }
+open-timeline-crud = { version = "0.1.2", path = "crates/crud" }
 open-timeline-games = { version = "0.1.0", path = "crates/games" }
 open-timeline-gui = { version = "0.1.0", path = "crates/gui" }
 open-timeline-gui-core = { version = "0.1.0", path = "crates/gui-core" }

--- a/crates/crud/.sqlx/query-00bf190fefd4ad2f9947f4fe96ec7f55f3fcdc03c27340208cb34df3ac4fde12.json
+++ b/crates/crud/.sqlx/query-00bf190fefd4ad2f9947f4fe96ec7f55f3fcdc03c27340208cb34df3ac4fde12.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT\n                name AS \"name: TagName\",\n                value AS \"value: TagValue\"\n            FROM timeline_tags\n            WHERE timeline_id=?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "name: TagName",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "value: TagValue",
+        "ordinal": 1,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      true,
+      false
+    ]
+  },
+  "hash": "00bf190fefd4ad2f9947f4fe96ec7f55f3fcdc03c27340208cb34df3ac4fde12"
+}

--- a/crates/crud/.sqlx/query-089c10d099bebbc07c9022c78f782f1deb4deda6a5d968cede966b993909dce8.json
+++ b/crates/crud/.sqlx/query-089c10d099bebbc07c9022c78f782f1deb4deda6a5d968cede966b993909dce8.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM entities;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": []
+  },
+  "hash": "089c10d099bebbc07c9022c78f782f1deb4deda6a5d968cede966b993909dce8"
+}

--- a/crates/crud/.sqlx/query-0e7fd3cab4dd8e1e4a55dd66b79e6ac79c73f7128685e96632671ca5a8f5a80a.json
+++ b/crates/crud/.sqlx/query-0e7fd3cab4dd8e1e4a55dd66b79e6ac79c73f7128685e96632671ca5a8f5a80a.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            DELETE FROM subtimelines\n            WHERE\n                    timeline_parent_id=?\n                OR\n                    timeline_child_id=?\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "0e7fd3cab4dd8e1e4a55dd66b79e6ac79c73f7128685e96632671ca5a8f5a80a"
+}

--- a/crates/crud/.sqlx/query-1063a67afa8600ae2dd1acd2e640d51bd030908f65ff61294357f707e3813f61.json
+++ b/crates/crud/.sqlx/query-1063a67afa8600ae2dd1acd2e640d51bd030908f65ff61294357f707e3813f61.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            DELETE FROM timeline_entities\n            WHERE timeline_id=? AND entity_id=?\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "1063a67afa8600ae2dd1acd2e640d51bd030908f65ff61294357f707e3813f61"
+}

--- a/crates/crud/.sqlx/query-1a0e1952cdde2832bee34894ae9692480a34da62ecf430be1a2cf325a1a4e8b6.json
+++ b/crates/crud/.sqlx/query-1a0e1952cdde2832bee34894ae9692480a34da62ecf430be1a2cf325a1a4e8b6.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT id AS \"id: OpenTimelineId\"\n            FROM timelines\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: OpenTimelineId",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "1a0e1952cdde2832bee34894ae9692480a34da62ecf430be1a2cf325a1a4e8b6"
+}

--- a/crates/crud/.sqlx/query-1cee30600aa66715115c503406ff7ea35613e0fa748f95ca4b899a77198c9087.json
+++ b/crates/crud/.sqlx/query-1cee30600aa66715115c503406ff7ea35613e0fa748f95ca4b899a77198c9087.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT COUNT(name) AS count\n            FROM entities\n            WHERE name=?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "count",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "1cee30600aa66715115c503406ff7ea35613e0fa748f95ca4b899a77198c9087"
+}

--- a/crates/crud/.sqlx/query-1e46ac5b740ed72e9f24c9450d05cd609fa05aa82c89aabcd6c2b8db7d329078.json
+++ b/crates/crud/.sqlx/query-1e46ac5b740ed72e9f24c9450d05cd609fa05aa82c89aabcd6c2b8db7d329078.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                INSERT INTO timeline_tags (timeline_id, name, value)\n                VALUES (?, ?, ?)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "1e46ac5b740ed72e9f24c9450d05cd609fa05aa82c89aabcd6c2b8db7d329078"
+}

--- a/crates/crud/.sqlx/query-1f41ba4c52180a4ce82a50af110fa8725c5b5e6f651dbacea2ad4b4a29a2decb.json
+++ b/crates/crud/.sqlx/query-1f41ba4c52180a4ce82a50af110fa8725c5b5e6f651dbacea2ad4b4a29a2decb.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT bool_expression\n            FROM timelines\n            WHERE id=?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "bool_expression",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "1f41ba4c52180a4ce82a50af110fa8725c5b5e6f651dbacea2ad4b4a29a2decb"
+}

--- a/crates/crud/.sqlx/query-21ca7598d1c23d62e4684d362a67f1fdba2eb477d9a788403b4940b6110bff15.json
+++ b/crates/crud/.sqlx/query-21ca7598d1c23d62e4684d362a67f1fdba2eb477d9a788403b4940b6110bff15.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                SELECT\n                    id AS \"id: OpenTimelineId\",\n                    name AS \"name: Name\",\n                    start_year,\n                    start_month,\n                    start_day,\n                    end_year,\n                    end_month,\n                    end_day\n                FROM entities\n                WHERE id=?\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: OpenTimelineId",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "name: Name",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "start_year",
+        "ordinal": 2,
+        "type_info": "Integer"
+      },
+      {
+        "name": "start_month",
+        "ordinal": 3,
+        "type_info": "Integer"
+      },
+      {
+        "name": "start_day",
+        "ordinal": 4,
+        "type_info": "Integer"
+      },
+      {
+        "name": "end_year",
+        "ordinal": 5,
+        "type_info": "Integer"
+      },
+      {
+        "name": "end_month",
+        "ordinal": 6,
+        "type_info": "Integer"
+      },
+      {
+        "name": "end_day",
+        "ordinal": 7,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "21ca7598d1c23d62e4684d362a67f1fdba2eb477d9a788403b4940b6110bff15"
+}

--- a/crates/crud/.sqlx/query-2403ab4cdb56cb5742041790fac9ec9bfb52312d8a0c435dc20b52560926610a.json
+++ b/crates/crud/.sqlx/query-2403ab4cdb56cb5742041790fac9ec9bfb52312d8a0c435dc20b52560926610a.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                    SELECT\n                        name AS \"name: TagName\",\n                        value AS \"value: TagValue\"\n                    FROM entity_tags\n                    WHERE entity_id=?\n                ",
+  "describe": {
+    "columns": [
+      {
+        "name": "name: TagName",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "value: TagValue",
+        "ordinal": 1,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      true,
+      false
+    ]
+  },
+  "hash": "2403ab4cdb56cb5742041790fac9ec9bfb52312d8a0c435dc20b52560926610a"
+}

--- a/crates/crud/.sqlx/query-265b73d255843b814b251c38af824353e9583d3683679f9fbd8fcdeebda7bd85.json
+++ b/crates/crud/.sqlx/query-265b73d255843b814b251c38af824353e9583d3683679f9fbd8fcdeebda7bd85.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM timelines;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": []
+  },
+  "hash": "265b73d255843b814b251c38af824353e9583d3683679f9fbd8fcdeebda7bd85"
+}

--- a/crates/crud/.sqlx/query-3267ef311d71ccf85e74fed00519dbc26d47f520ece23c49964410586404f1a0.json
+++ b/crates/crud/.sqlx/query-3267ef311d71ccf85e74fed00519dbc26d47f520ece23c49964410586404f1a0.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            UPDATE entity_tags\n            SET\n                name = ?,\n                value = ?\n            WHERE \n                    (name IS ? OR name = ?)\n                AND\n                    value = ?;\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 5
+    },
+    "nullable": []
+  },
+  "hash": "3267ef311d71ccf85e74fed00519dbc26d47f520ece23c49964410586404f1a0"
+}

--- a/crates/crud/.sqlx/query-3d462c7dacf155a8859e6b52efe1c111302f267bc16b45bfa6a85dd62a69d63c.json
+++ b/crates/crud/.sqlx/query-3d462c7dacf155a8859e6b52efe1c111302f267bc16b45bfa6a85dd62a69d63c.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                INSERT INTO subtimelines (timeline_parent_id, timeline_child_id) \n                VALUES (?, ?)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "3d462c7dacf155a8859e6b52efe1c111302f267bc16b45bfa6a85dd62a69d63c"
+}

--- a/crates/crud/.sqlx/query-450d5ac2e9519ebc5ae6aea201a4288fb7687cfa9c59bb5ea80dbebe47c6d8b8.json
+++ b/crates/crud/.sqlx/query-450d5ac2e9519ebc5ae6aea201a4288fb7687cfa9c59bb5ea80dbebe47c6d8b8.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT name AS \"name: Name\"\n            FROM entities\n            WHERE id=?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "name: Name",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "450d5ac2e9519ebc5ae6aea201a4288fb7687cfa9c59bb5ea80dbebe47c6d8b8"
+}

--- a/crates/crud/.sqlx/query-45a6542948e49dda77c8bc8ac560c6a16d51920a4c8348b68fea816858448b31.json
+++ b/crates/crud/.sqlx/query-45a6542948e49dda77c8bc8ac560c6a16d51920a4c8348b68fea816858448b31.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            DELETE FROM timeline_tags\n            WHERE timeline_id=?\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "45a6542948e49dda77c8bc8ac560c6a16d51920a4c8348b68fea816858448b31"
+}

--- a/crates/crud/.sqlx/query-47b5d47622b3a6ef5a5aa141db47bbc13679e3299c62430c6dd4bfe1cac96765.json
+++ b/crates/crud/.sqlx/query-47b5d47622b3a6ef5a5aa141db47bbc13679e3299c62430c6dd4bfe1cac96765.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                INSERT INTO timeline_entities (timeline_id, entity_id)\n                VALUES (?, ?)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "47b5d47622b3a6ef5a5aa141db47bbc13679e3299c62430c6dd4bfe1cac96765"
+}

--- a/crates/crud/.sqlx/query-4e67c598ba9c978997c701a432af07ec14b48acae9171d1c260274ca89333927.json
+++ b/crates/crud/.sqlx/query-4e67c598ba9c978997c701a432af07ec14b48acae9171d1c260274ca89333927.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT COUNT(name) AS count\n            FROM timelines\n            WHERE name=?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "count",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "4e67c598ba9c978997c701a432af07ec14b48acae9171d1c260274ca89333927"
+}

--- a/crates/crud/.sqlx/query-4e9591e133250ee965b929d56f23231bbf98cdb8a70cb86ba9ef61bb5252c72d.json
+++ b/crates/crud/.sqlx/query-4e9591e133250ee965b929d56f23231bbf98cdb8a70cb86ba9ef61bb5252c72d.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT\n                name AS \"name: TagName\",\n                value AS \"value: TagValue\"\n            FROM entity_tags\n            UNION\n            SELECT\n                name AS \"name: TagName\",\n                value AS \"value: TagValue\"\n            FROM timeline_tags\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "name: TagName",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "value: TagValue",
+        "ordinal": 1,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      true,
+      false
+    ]
+  },
+  "hash": "4e9591e133250ee965b929d56f23231bbf98cdb8a70cb86ba9ef61bb5252c72d"
+}

--- a/crates/crud/.sqlx/query-510fe60966a0804c25def8733bcc5773ebc8111c13c144392f448ff0ee8dff9d.json
+++ b/crates/crud/.sqlx/query-510fe60966a0804c25def8733bcc5773ebc8111c13c144392f448ff0ee8dff9d.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                SELECT DISTINCT\n                    id AS \"id: OpenTimelineId\",\n                    name AS \"name: Name\"\n                FROM entities\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: OpenTimelineId",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "name: Name",
+        "ordinal": 1,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "510fe60966a0804c25def8733bcc5773ebc8111c13c144392f448ff0ee8dff9d"
+}

--- a/crates/crud/.sqlx/query-569f341f771f3e5ade580e8b76e88c84ded8f006e540d407943ffa35aad1a5bf.json
+++ b/crates/crud/.sqlx/query-569f341f771f3e5ade580e8b76e88c84ded8f006e540d407943ffa35aad1a5bf.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM subtimelines;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": []
+  },
+  "hash": "569f341f771f3e5ade580e8b76e88c84ded8f006e540d407943ffa35aad1a5bf"
+}

--- a/crates/crud/.sqlx/query-56ab01f3b85191751971b1217bf55d936b3459a91927082ad118f1b20c66187c.json
+++ b/crates/crud/.sqlx/query-56ab01f3b85191751971b1217bf55d936b3459a91927082ad118f1b20c66187c.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM entity_tags;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": []
+  },
+  "hash": "56ab01f3b85191751971b1217bf55d936b3459a91927082ad118f1b20c66187c"
+}

--- a/crates/crud/.sqlx/query-57221c756792d29c4e4b0bdba3377f3a2ec3702b6a0da2cb9f3478dde6e3a7db.json
+++ b/crates/crud/.sqlx/query-57221c756792d29c4e4b0bdba3377f3a2ec3702b6a0da2cb9f3478dde6e3a7db.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT id AS \"id: OpenTimelineId\"\n            FROM timelines\n            WHERE name=?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: OpenTimelineId",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "57221c756792d29c4e4b0bdba3377f3a2ec3702b6a0da2cb9f3478dde6e3a7db"
+}

--- a/crates/crud/.sqlx/query-698e17a33ba607beab0683b92bede396cb78ff5cb58a5b19fa650a04ddfd86ab.json
+++ b/crates/crud/.sqlx/query-698e17a33ba607beab0683b92bede396cb78ff5cb58a5b19fa650a04ddfd86ab.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM timeline_tags;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": []
+  },
+  "hash": "698e17a33ba607beab0683b92bede396cb78ff5cb58a5b19fa650a04ddfd86ab"
+}

--- a/crates/crud/.sqlx/query-70a1bef65a7b2ef1a69650d56bf1cac3144265183a4cce4c340f1595ad9b63f4.json
+++ b/crates/crud/.sqlx/query-70a1bef65a7b2ef1a69650d56bf1cac3144265183a4cce4c340f1595ad9b63f4.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT\n                timeline_entities.timeline_id AS \"timeline_id: OpenTimelineId\",\n                timelines.name AS \"timeline_name: Name\"\n            FROM timeline_entities\n            JOIN timelines ON\n                timeline_entities.timeline_id = timelines.id\n            WHERE entity_id=?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "timeline_id: OpenTimelineId",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "timeline_name: Name",
+        "ordinal": 1,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "70a1bef65a7b2ef1a69650d56bf1cac3144265183a4cce4c340f1595ad9b63f4"
+}

--- a/crates/crud/.sqlx/query-7adc2113fa8b7f3ae2bae8fdc4f5a4e896d3899a0d337204a3adbd60e4cff8d5.json
+++ b/crates/crud/.sqlx/query-7adc2113fa8b7f3ae2bae8fdc4f5a4e896d3899a0d337204a3adbd60e4cff8d5.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                SELECT id AS \"id: OpenTimelineId\"\n                FROM entities\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: OpenTimelineId",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "7adc2113fa8b7f3ae2bae8fdc4f5a4e896d3899a0d337204a3adbd60e4cff8d5"
+}

--- a/crates/crud/.sqlx/query-7ca266f9cafecde291cfe813fbad3d4277551b6f84afefdcdfdc5249f570d3e2.json
+++ b/crates/crud/.sqlx/query-7ca266f9cafecde291cfe813fbad3d4277551b6f84afefdcdfdc5249f570d3e2.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT\n                name AS \"name: TagName\",\n                value AS \"value: TagValue\",\n                COUNT(*) AS count\n            FROM timeline_tags\n            GROUP BY name, value\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "name: TagName",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "value: TagValue",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "count",
+        "ordinal": 2,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "7ca266f9cafecde291cfe813fbad3d4277551b6f84afefdcdfdc5249f570d3e2"
+}

--- a/crates/crud/.sqlx/query-827feb0ce3dc48cb41df8d2ec0d1a73db85ff5f8af398b97d978b802fd373d26.json
+++ b/crates/crud/.sqlx/query-827feb0ce3dc48cb41df8d2ec0d1a73db85ff5f8af398b97d978b802fd373d26.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                DELETE FROM entities\n                WHERE id=?\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "827feb0ce3dc48cb41df8d2ec0d1a73db85ff5f8af398b97d978b802fd373d26"
+}

--- a/crates/crud/.sqlx/query-8557dd3563305aa12fa91e34164c346174f0529fafd2789b29897ab5d0feb130.json
+++ b/crates/crud/.sqlx/query-8557dd3563305aa12fa91e34164c346174f0529fafd2789b29897ab5d0feb130.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            DELETE FROM timeline_entities\n            WHERE timeline_id = ?\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "8557dd3563305aa12fa91e34164c346174f0529fafd2789b29897ab5d0feb130"
+}

--- a/crates/crud/.sqlx/query-89c531fcdd23634b84e6379e2e77b5dc0a2adf9d338849c3f88fd85d5fcfcb3e.json
+++ b/crates/crud/.sqlx/query-89c531fcdd23634b84e6379e2e77b5dc0a2adf9d338849c3f88fd85d5fcfcb3e.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            DELETE FROM timeline_tags\n            WHERE \n                    (name IS ? OR name = ?)\n                AND\n                    value = ?;\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "89c531fcdd23634b84e6379e2e77b5dc0a2adf9d338849c3f88fd85d5fcfcb3e"
+}

--- a/crates/crud/.sqlx/query-8df7279cb03c19745ad43b1300e541965b90c3fec29b7deab29f013b0ec419ec.json
+++ b/crates/crud/.sqlx/query-8df7279cb03c19745ad43b1300e541965b90c3fec29b7deab29f013b0ec419ec.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                INSERT INTO entities\n                (\n                    id,\n                    name,\n                    start_year,\n                    start_month,\n                    start_day,\n                    end_year,\n                    end_month,\n                    end_day\n                )\n                VALUES (?, ?, ?, ?, ?, ?, ?, ?)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 8
+    },
+    "nullable": []
+  },
+  "hash": "8df7279cb03c19745ad43b1300e541965b90c3fec29b7deab29f013b0ec419ec"
+}

--- a/crates/crud/.sqlx/query-96ab229c8b34571cde5652892261e06d95c8d34e56043dcc81725b95d19fdb5b.json
+++ b/crates/crud/.sqlx/query-96ab229c8b34571cde5652892261e06d95c8d34e56043dcc81725b95d19fdb5b.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM timeline_entities;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": []
+  },
+  "hash": "96ab229c8b34571cde5652892261e06d95c8d34e56043dcc81725b95d19fdb5b"
+}

--- a/crates/crud/.sqlx/query-9ae70f1ef70aeb613b1e937a8b373bb98c4d1a5e07a4622534a899a937ca79e7.json
+++ b/crates/crud/.sqlx/query-9ae70f1ef70aeb613b1e937a8b373bb98c4d1a5e07a4622534a899a937ca79e7.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                    UPDATE timelines\n                    SET\n                        name = ?,\n                        bool_expression = ?\n                    WHERE id = ?\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "9ae70f1ef70aeb613b1e937a8b373bb98c4d1a5e07a4622534a899a937ca79e7"
+}

--- a/crates/crud/.sqlx/query-9f5d9353e43fe21e46fce4835b896e7935eef70cd71415a072bb356d87ba811d.json
+++ b/crates/crud/.sqlx/query-9f5d9353e43fe21e46fce4835b896e7935eef70cd71415a072bb356d87ba811d.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                SELECT id AS \"id: OpenTimelineId\"\n                FROM entities\n                WHERE end_year IS NOT NULL\n                ORDER BY RANDOM()\n                LIMIT ?\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: OpenTimelineId",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9f5d9353e43fe21e46fce4835b896e7935eef70cd71415a072bb356d87ba811d"
+}

--- a/crates/crud/.sqlx/query-9f71ff7c251cff71e0e7a8fed24f428b1a05286566f286f4075332daefa56df6.json
+++ b/crates/crud/.sqlx/query-9f71ff7c251cff71e0e7a8fed24f428b1a05286566f286f4075332daefa56df6.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                SELECT\n                    id AS \"id: OpenTimelineId\",\n                    name AS \"name: Name\"\n                FROM timelines\n                WHERE name LIKE CONCAT('%', ?, '%')\n                ORDER BY RANDOM()\n                LIMIT ?\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: OpenTimelineId",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "name: Name",
+        "ordinal": 1,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "9f71ff7c251cff71e0e7a8fed24f428b1a05286566f286f4075332daefa56df6"
+}

--- a/crates/crud/.sqlx/query-9f8c69e4b3793b1308196599de0b3d8a1924f2cb4e5d0aba2b481710ea2b8b13.json
+++ b/crates/crud/.sqlx/query-9f8c69e4b3793b1308196599de0b3d8a1924f2cb4e5d0aba2b481710ea2b8b13.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                INSERT INTO entity_tags (entity_id, name, value)\n                VALUES (?, ?, ?)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "9f8c69e4b3793b1308196599de0b3d8a1924f2cb4e5d0aba2b481710ea2b8b13"
+}

--- a/crates/crud/.sqlx/query-a25cf08f3a1a7fce86b58f1641a3d28cc0869082d72d6b6e992b796731731bf2.json
+++ b/crates/crud/.sqlx/query-a25cf08f3a1a7fce86b58f1641a3d28cc0869082d72d6b6e992b796731731bf2.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                SELECT DISTINCT\n                    id AS \"id: OpenTimelineId\",\n                    name AS \"name: Name\"\n                FROM timelines\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: OpenTimelineId",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "name: Name",
+        "ordinal": 1,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "a25cf08f3a1a7fce86b58f1641a3d28cc0869082d72d6b6e992b796731731bf2"
+}

--- a/crates/crud/.sqlx/query-a93f8d98aff02054ce8a520f383789f1e65f296f7dc35fcd3ac816ec7e6cb086.json
+++ b/crates/crud/.sqlx/query-a93f8d98aff02054ce8a520f383789f1e65f296f7dc35fcd3ac816ec7e6cb086.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT COUNT(id) AS count\n            FROM timelines\n            WHERE id=?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "count",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "a93f8d98aff02054ce8a520f383789f1e65f296f7dc35fcd3ac816ec7e6cb086"
+}

--- a/crates/crud/.sqlx/query-ab4bf5346ecfbdbe36e4337fce4acbd6b1c9d8c737cd45cf3ae6d78f5eced94e.json
+++ b/crates/crud/.sqlx/query-ab4bf5346ecfbdbe36e4337fce4acbd6b1c9d8c737cd45cf3ae6d78f5eced94e.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            DELETE FROM entity_tags\n            WHERE entity_id=?\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "ab4bf5346ecfbdbe36e4337fce4acbd6b1c9d8c737cd45cf3ae6d78f5eced94e"
+}

--- a/crates/crud/.sqlx/query-b4ccb5936c9009aa8cd295bb63dd90cd030b1c0aef27c1f7f7fadfef57ed9fbc.json
+++ b/crates/crud/.sqlx/query-b4ccb5936c9009aa8cd295bb63dd90cd030b1c0aef27c1f7f7fadfef57ed9fbc.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            DELETE FROM subtimelines\n            WHERE timeline_parent_id=?\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "b4ccb5936c9009aa8cd295bb63dd90cd030b1c0aef27c1f7f7fadfef57ed9fbc"
+}

--- a/crates/crud/.sqlx/query-b532d21b2ecd266479f053204e9a9c42300ac10d0758dadbb3f7196d2325a585.json
+++ b/crates/crud/.sqlx/query-b532d21b2ecd266479f053204e9a9c42300ac10d0758dadbb3f7196d2325a585.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT id AS \"id: OpenTimelineId\"\n            FROM entities\n            WHERE name=?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: OpenTimelineId",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "b532d21b2ecd266479f053204e9a9c42300ac10d0758dadbb3f7196d2325a585"
+}

--- a/crates/crud/.sqlx/query-b87459f97a35bcf2144a357ec401a1ae83affc7d2cbd661886915895657bcc01.json
+++ b/crates/crud/.sqlx/query-b87459f97a35bcf2144a357ec401a1ae83affc7d2cbd661886915895657bcc01.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT name AS \"name: Name\"\n            FROM timelines\n            WHERE id=?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "name: Name",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "b87459f97a35bcf2144a357ec401a1ae83affc7d2cbd661886915895657bcc01"
+}

--- a/crates/crud/.sqlx/query-c50f3b0352d89bd9be97ab66edd191843c05c78cc617d6f91f3da0ca6d084249.json
+++ b/crates/crud/.sqlx/query-c50f3b0352d89bd9be97ab66edd191843c05c78cc617d6f91f3da0ca6d084249.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT COUNT(id) AS count\n            FROM entities\n            WHERE id=?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "count",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "c50f3b0352d89bd9be97ab66edd191843c05c78cc617d6f91f3da0ca6d084249"
+}

--- a/crates/crud/.sqlx/query-cdf11753fa18a415c00b4cef117e697babf5f85120eb4f9356fcd4b9c9802ab0.json
+++ b/crates/crud/.sqlx/query-cdf11753fa18a415c00b4cef117e697babf5f85120eb4f9356fcd4b9c9802ab0.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            DELETE FROM timelines\n            WHERE id=?\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "cdf11753fa18a415c00b4cef117e697babf5f85120eb4f9356fcd4b9c9802ab0"
+}

--- a/crates/crud/.sqlx/query-d000786437380e91a40893c2ba0cbc4f1bc5e03c05bf0e94c22cc130e835918f.json
+++ b/crates/crud/.sqlx/query-d000786437380e91a40893c2ba0cbc4f1bc5e03c05bf0e94c22cc130e835918f.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT\n                name AS \"name: TagName\",\n                value AS \"value: TagValue\",\n                COUNT(*) AS count\n            FROM entity_tags\n            GROUP BY name, value\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "name: TagName",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "value: TagValue",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "count",
+        "ordinal": 2,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "d000786437380e91a40893c2ba0cbc4f1bc5e03c05bf0e94c22cc130e835918f"
+}

--- a/crates/crud/.sqlx/query-d54a820e174a9dd4b4cde949f71d178a5103eb6dc5af98ba9691c43238eac142.json
+++ b/crates/crud/.sqlx/query-d54a820e174a9dd4b4cde949f71d178a5103eb6dc5af98ba9691c43238eac142.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            INSERT INTO timeline_entities (timeline_id, entity_id)\n            VALUES (?, ?)\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "d54a820e174a9dd4b4cde949f71d178a5103eb6dc5af98ba9691c43238eac142"
+}

--- a/crates/crud/.sqlx/query-d67c79c1cf0f30034ad8dcd07a0a8c682a316b865e36ca7696a2d88f47eee528.json
+++ b/crates/crud/.sqlx/query-d67c79c1cf0f30034ad8dcd07a0a8c682a316b865e36ca7696a2d88f47eee528.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT DISTINCT\n                timelines.id AS \"id: OpenTimelineId\",\n                timelines.name AS \"name: Name\"\n            FROM timelines\n            JOIN timeline_tags ON timelines.id = timeline_tags.timeline_id\n            WHERE\n            (\n                timeline_tags.name = ?\n                OR (timeline_tags.name IS NULL AND ? IS NULL)\n            )\n            AND timeline_tags.value = ?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: OpenTimelineId",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "name: Name",
+        "ordinal": 1,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "d67c79c1cf0f30034ad8dcd07a0a8c682a316b865e36ca7696a2d88f47eee528"
+}

--- a/crates/crud/.sqlx/query-d9a8f56cf8577a25aa79883236d8cfa427a5c77759fa9c76564712fed374d8c8.json
+++ b/crates/crud/.sqlx/query-d9a8f56cf8577a25aa79883236d8cfa427a5c77759fa9c76564712fed374d8c8.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT timeline_child_id AS \"timeline_child_id: OpenTimelineId\"\n            FROM subtimelines\n            WHERE timeline_parent_id=?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "timeline_child_id: OpenTimelineId",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "d9a8f56cf8577a25aa79883236d8cfa427a5c77759fa9c76564712fed374d8c8"
+}

--- a/crates/crud/.sqlx/query-dbda6ce35111cb730a8df4d47939b4208d66dc92b5864d9bbe458927eb8160c8.json
+++ b/crates/crud/.sqlx/query-dbda6ce35111cb730a8df4d47939b4208d66dc92b5864d9bbe458927eb8160c8.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT DISTINCT\n                entities.id AS \"id: OpenTimelineId\",\n                entities.name AS \"name: Name\"\n            FROM entities\n            JOIN entity_tags ON entities.id = entity_tags.entity_id\n            WHERE\n            (\n                entity_tags.name = ?\n                OR (entity_tags.name IS NULL AND ? IS NULL)\n            )\n            AND entity_tags.value = ?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: OpenTimelineId",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "name: Name",
+        "ordinal": 1,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "dbda6ce35111cb730a8df4d47939b4208d66dc92b5864d9bbe458927eb8160c8"
+}

--- a/crates/crud/.sqlx/query-dd00b4ca093bfa27c755d40dbb59541e913a6f90bf2be5f750b0d1aaf93fd7eb.json
+++ b/crates/crud/.sqlx/query-dd00b4ca093bfa27c755d40dbb59541e913a6f90bf2be5f750b0d1aaf93fd7eb.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            DELETE FROM timeline_entities\n            WHERE entity_id=?\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "dd00b4ca093bfa27c755d40dbb59541e913a6f90bf2be5f750b0d1aaf93fd7eb"
+}

--- a/crates/crud/.sqlx/query-dd06cc73400072aeb15294d1ddc87780e60f7816efee3263d7679b912186f072.json
+++ b/crates/crud/.sqlx/query-dd06cc73400072aeb15294d1ddc87780e60f7816efee3263d7679b912186f072.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE entities\n                SET\n                    start_year = ?,\n                    start_month = ?,\n                    start_day = ?,\n                    end_year = ?,\n                    end_month = ?,\n                    end_day = ?\n                WHERE id = ?\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 7
+    },
+    "nullable": []
+  },
+  "hash": "dd06cc73400072aeb15294d1ddc87780e60f7816efee3263d7679b912186f072"
+}

--- a/crates/crud/.sqlx/query-ddb0e599592778c351e16c1c759c841f1bbce2108b42f5b0b23b5831b2951155.json
+++ b/crates/crud/.sqlx/query-ddb0e599592778c351e16c1c759c841f1bbce2108b42f5b0b23b5831b2951155.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            INSERT INTO timelines (id, name, bool_expression)\n            VALUES (?, ?, ?)\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "ddb0e599592778c351e16c1c759c841f1bbce2108b42f5b0b23b5831b2951155"
+}

--- a/crates/crud/.sqlx/query-e15f42e660471d22c9ccfa3d09811ec9daa17d9f206da1fd37c02d942a4aada0.json
+++ b/crates/crud/.sqlx/query-e15f42e660471d22c9ccfa3d09811ec9daa17d9f206da1fd37c02d942a4aada0.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                    UPDATE entities\n                    SET name = ?\n                    WHERE id = ?\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "e15f42e660471d22c9ccfa3d09811ec9daa17d9f206da1fd37c02d942a4aada0"
+}

--- a/crates/crud/.sqlx/query-e2b2f5d662007c2ad29d0484ad95e144099b5e80bc66b2d2cc0b2228b51c9d85.json
+++ b/crates/crud/.sqlx/query-e2b2f5d662007c2ad29d0484ad95e144099b5e80bc66b2d2cc0b2228b51c9d85.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT COUNT(*) AS count\n            FROM timeline_entities\n            WHERE timeline_id=? AND entity_id=?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "count",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "e2b2f5d662007c2ad29d0484ad95e144099b5e80bc66b2d2cc0b2228b51c9d85"
+}

--- a/crates/crud/.sqlx/query-e3f9df526f4bcaad7cdf16369c3435c85ceedcbbfdd148005844dbfca286d03e.json
+++ b/crates/crud/.sqlx/query-e3f9df526f4bcaad7cdf16369c3435c85ceedcbbfdd148005844dbfca286d03e.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT id AS \"id: OpenTimelineId\"\n            FROM entities\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: OpenTimelineId",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "e3f9df526f4bcaad7cdf16369c3435c85ceedcbbfdd148005844dbfca286d03e"
+}

--- a/crates/crud/.sqlx/query-e6c9d691408e93f620ac640ae384aa3e16b044c1a63e1da9d21901ad7114f3d8.json
+++ b/crates/crud/.sqlx/query-e6c9d691408e93f620ac640ae384aa3e16b044c1a63e1da9d21901ad7114f3d8.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT entity_id AS \"entity_id: OpenTimelineId\"\n            FROM timeline_entities\n            WHERE timeline_id=?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "entity_id: OpenTimelineId",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "e6c9d691408e93f620ac640ae384aa3e16b044c1a63e1da9d21901ad7114f3d8"
+}

--- a/crates/crud/.sqlx/query-f13dcf8c1e8a1805ac403643a168823ff30f0f1124df5982db1c4063ea3041ef.json
+++ b/crates/crud/.sqlx/query-f13dcf8c1e8a1805ac403643a168823ff30f0f1124df5982db1c4063ea3041ef.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                SELECT id AS \"id: OpenTimelineId\"\n                FROM timelines\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: OpenTimelineId",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "f13dcf8c1e8a1805ac403643a168823ff30f0f1124df5982db1c4063ea3041ef"
+}

--- a/crates/crud/.sqlx/query-f64c11096b74078697262ac926574e799b4e23b4f24a6fb1c0461b356b600954.json
+++ b/crates/crud/.sqlx/query-f64c11096b74078697262ac926574e799b4e23b4f24a6fb1c0461b356b600954.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            DELETE FROM entity_tags\n            WHERE \n                    (name IS ? OR name = ?)\n                AND\n                    value = ?;\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "f64c11096b74078697262ac926574e799b4e23b4f24a6fb1c0461b356b600954"
+}

--- a/crates/crud/.sqlx/query-fc09286b3c88bba7d7cb2bdac658f529cca3a6feeb99eaf7de88e35f19d06b97.json
+++ b/crates/crud/.sqlx/query-fc09286b3c88bba7d7cb2bdac658f529cca3a6feeb99eaf7de88e35f19d06b97.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                SELECT\n                    id AS \"id: OpenTimelineId\",\n                    name AS \"name: Name\"\n                FROM entities\n                WHERE name LIKE CONCAT('%', ?, '%')\n                ORDER BY RANDOM()\n                LIMIT ?\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: OpenTimelineId",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "name: Name",
+        "ordinal": 1,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "fc09286b3c88bba7d7cb2bdac658f529cca3a6feeb99eaf7de88e35f19d06b97"
+}

--- a/crates/crud/Cargo.toml
+++ b/crates/crud/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-timeline-crud"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "GPL-3.0-or-later"
 description = "OpenTimeline CRUD"
@@ -9,6 +9,7 @@ homepage = "https://github.com/harryhudson/open-timeline"
 include = [
     "src/**",
     "Cargo.toml",
+    ".sqlx/**",
     "migrations/**"
 ]
 
@@ -21,6 +22,6 @@ derive_more = { version = "2.0.1", features = ["into_iterator", "index"] }
 log = "0.4.25"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.135"
-sqlx = { version = "0.8.3", default-features = false, features = ["macros", "runtime-tokio", "sqlite", "migrate"] }
+sqlx = { version = "0.8.3", default-features = false }
 thiserror = "2.0.11"
 tokio = { version = "1.42.0", default-features = false, features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
Before this change, the published `crud` crate wasn't working as intended: the `www-api` crate, for example, could not be published because it depended on the published `crud` crate which could not be compiled due to there not being a database available for SQLx (the SQLx macros, such as `query!()` were raising errors). This change adds the database migrations and, crucially, the offline (`cargo sqlx prepare -- --offline --workspace`) queries so that downstream consumers of the `crud` crate do not need to setup a database at compile time.