### PR TITLE
Don't reload GUI windows unnecessarily (fix #38)

### DIFF
--- a/crates/gui/src/windows/entity_edit.rs
+++ b/crates/gui/src/windows/entity_edit.rs
@@ -462,6 +462,9 @@ impl Reload for EntityEditGui {
         if self.has_been_deleted() {
             return;
         }
+        if self.create_or_edit == CreateOrEdit::Create {
+            return;
+        }
         match self.entity_id {
             Some(entity_id) => {
                 self.requested_reload = true;
@@ -490,7 +493,16 @@ impl Reload for EntityEditGui {
                     self.rx_reload = None;
                     self.requested_reload = false;
                     match result {
-                        Ok(entity) => self.set_from_entity(entity),
+                        Ok(entity) => {
+                            // If the entity hasn't changed in the database, ignore the
+                            // newly fetched one (don't set)
+                            if let Some(database_entry) = self.database_entry.as_ref() {
+                                if *database_entry == entity {
+                                    return;
+                                }
+                            }
+                            self.set_from_entity(entity);
+                        }
                         Err(CrudError::IdNotInDb) => {
                             self.set_deleted_status(DeletedStatus::Deleted(Instant::now()))
                         }

--- a/crates/gui/src/windows/timeline_edit.rs
+++ b/crates/gui/src/windows/timeline_edit.rs
@@ -520,6 +520,9 @@ impl Reload for TimelineEditGui {
         if self.has_been_deleted() {
             return;
         }
+        if self.create_or_edit == CreateOrEdit::Create {
+            return;
+        }
         match self.timeline_id {
             Some(timeline_id) => {
                 self.requested_reload = true;
@@ -547,7 +550,16 @@ impl Reload for TimelineEditGui {
                     self.rx_reload = None;
                     self.requested_reload = false;
                     match result {
-                        Ok(timeline) => self.set_from_timeline(timeline),
+                        Ok(timeline) => {
+                            // If the database hasn't changed in the database, ignore the
+                            // newly fetched one (don't set)
+                            if let Some(database_entry) = self.database_entry.as_ref() {
+                                if *database_entry == timeline {
+                                    return;
+                                }
+                            }
+                            self.set_from_timeline(timeline);
+                        }
                         Err(CrudError::IdNotInDb) => {
                             self.set_deleted_status(DeletedStatus::Deleted(Instant::now()))
                         }


### PR DESCRIPTION
The following bugs are fixed by this change:

- When one opened a window to create an entity, then edited & saved (or deleted) an entity in a different window, the window for creating a new entity would close, claiming it had been deleted.
    - Likewise for timeline windows
- When one opened a window to edit an existing entity, then edited & saved (or deleted)  a different entity in a different window, the window for editing the first entity would reset, discarding the changes made.
    - Likewise for timeline windows
